### PR TITLE
whitelist_rules = only_rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-whitelist_rules:
+only_rules:
     - attributes
     - block_based_kvo
     - class_delegate_protocol


### PR DESCRIPTION
The whitelist_rules configuration key has been renamed to only_rules on version 0.41.0 (Nov 8, 2020) https://github.com/realm/SwiftLint/releases/tag/0.41.0