### PR TITLE
BetterDisplay support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,4 +1,4 @@
-whitelist_rules:
+only_rules:
     - attributes
     - block_based_kvo
     - class_delegate_protocol

--- a/MultiSoundChanger.xcodeproj/project.pbxproj
+++ b/MultiSoundChanger.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		F3925975262F2B8000B7AD62 /* ApplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3925974262F2B8000B7AD62 /* ApplicationController.swift */; };
 		F3925979262F2F9F00B7AD62 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3925978262F2F9F00B7AD62 /* Logger.swift */; };
 		F392597C2631ACE700B7AD62 /* Runner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F392597B2631ACE700B7AD62 /* Runner.swift */; };
+		F7E845072CF9F96D0001647F /* BetterDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7E845062CF9F96D0001647F /* BetterDisplay.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -58,6 +59,7 @@
 		F3925974262F2B8000B7AD62 /* ApplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationController.swift; sourceTree = "<group>"; };
 		F3925978262F2F9F00B7AD62 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		F392597B2631ACE700B7AD62 /* Runner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Runner.swift; sourceTree = "<group>"; };
+		F7E845062CF9F96D0001647F /* BetterDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetterDisplay.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -224,6 +226,7 @@
 			children = (
 				F3925978262F2F9F00B7AD62 /* Logger.swift */,
 				F392597B2631ACE700B7AD62 /* Runner.swift */,
+				F7E845062CF9F96D0001647F /* BetterDisplay.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -381,6 +384,7 @@
 				F373D8B52561D1A600642274 /* MediaManager.swift in Sources */,
 				F373D8B42561D1A600642274 /* AudioManager.swift in Sources */,
 				F373D8B32561D1A600642274 /* StatusBarController.swift in Sources */,
+				F7E845072CF9F96D0001647F /* BetterDisplay.swift in Sources */,
 				4743EFAB1E91493B0032F5AA /* AppDelegate.swift in Sources */,
 				F373D8BF2561D22000642274 /* VolumeViewController.swift in Sources */,
 				F3925979262F2F9F00B7AD62 /* Logger.swift in Sources */,

--- a/MultiSoundChanger/Other/Constants.swift
+++ b/MultiSoundChanger/Other/Constants.swift
@@ -51,5 +51,13 @@ enum Constants {
         static func selectedDeviceVolume(volume: String) -> String {
             return "Selected device volume: \(volume)"
         }
+        
+        static func deviceDoesNotSupportVolume(deviceName: String) -> String {
+            return "The device \(deviceName) does not support volume control"
+        }
+        
+        static func deviceDoesNotSupportMute(deviceName: String) -> String {
+            return "The device \(deviceName) does not support mute control"
+        }
     }
 }

--- a/MultiSoundChanger/Sources/Utils/BetterDisplay.swift
+++ b/MultiSoundChanger/Sources/Utils/BetterDisplay.swift
@@ -6,36 +6,38 @@
 //  Copyright © 2021 Dmitry Medyuho. All rights reserved.
 //
 
-import Foundation
+import AppKit
 
 enum BetterDisplay {
     private static let executablePath = "/Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay"
+    private static let requestNotificationName = NSNotification.Name("com.betterdisplay.BetterDisplay.request")
     
-    private static func isInstalled() -> Bool {
-        FileManager.default.fileExists(atPath: BetterDisplay.executablePath)
+    private struct IntegrationNotificationRequestData: Codable {
+        var uuid: String?
+        var commands: [String] = []
+        var parameters: [String: String?] = [:]
     }
+
+    private static let isInstalled: Bool = FileManager.default.fileExists(atPath: executablePath)
     
-    ///
-    /// While there's DistributedNotificationCenter based integration available by using CLIinstead
-    /// we assure the command will execute even if BetterDisplay wasn't already running.
-    ///
-    @discardableResult
-    static private func set(_ parameter: String, value: String, deviceName: String) -> String? {
-        if BetterDisplay.isInstalled() {
-            let bdCmd = "\(BetterDisplay.executablePath) set -n=\"\(deviceName)\" -\(parameter)=\(value)"
-            Logger.debug("Executing BetterDisplay command: \(bdCmd)")
-            return Runner.shell(bdCmd)
+    private static func set(_ parameter: String, value: String, deviceName: String) {
+        if !isInstalled {
+            return
         }
-        return nil
+        let data = IntegrationNotificationRequestData(uuid: UUID().uuidString, commands: ["n", "set"], parameters: [deviceName: "", parameter: value])
+        do {
+            let encodedData = try JSONEncoder().encode(data)
+            if let encodedDataString = String(data: encodedData, encoding: .utf8) {
+                DistributedNotificationCenter.default().postNotificationName(requestNotificationName, object: encodedDataString, userInfo: nil, deliverImmediately: true)
+            }
+        } catch {}
     }
     
-    @discardableResult
-    static func setVolume(_ volume: Float, deviceName: String) -> String? {
-        return BetterDisplay.set("volume", value: String(volume), deviceName: deviceName)
+    static func setVolume(_ volume: Float, deviceName: String) {
+        set("volume", value: String(volume), deviceName: deviceName)
     }
     
-    @discardableResult
-    static func mute(_ mute: Bool, deviceName: String) -> String? {
-        return BetterDisplay.set("mute", value: mute ? "on" : "off", deviceName: deviceName)
+    static func mute(_ mute: Bool, deviceName: String) {
+        set("mute", value: mute ? "on" : "off", deviceName: deviceName)
     }
 }

--- a/MultiSoundChanger/Sources/Utils/BetterDisplay.swift
+++ b/MultiSoundChanger/Sources/Utils/BetterDisplay.swift
@@ -1,0 +1,41 @@
+//
+//  BetterDisplay.swift
+//  MultiSoundChanger
+//
+//  Created by aone on 29.11.24.
+//  Copyright © 2021 Dmitry Medyuho. All rights reserved.
+//
+
+import Foundation
+
+enum BetterDisplay {
+    private static let executablePath = "/Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay"
+    
+    private static func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: BetterDisplay.executablePath)
+    }
+    
+    ///
+    /// While there's DistributedNotificationCenter based integration available by using CLIinstead
+    /// we assure the command will execute even if BetterDisplay wasn't already running.
+    ///
+    @discardableResult
+    static private func set(_ parameter: String, value: String, deviceName: String) -> String? {
+        if BetterDisplay.isInstalled() {
+            let bdCmd = "\(BetterDisplay.executablePath) set -n=\"\(deviceName)\" -\(parameter)=\(value)"
+            Logger.debug("Executing BetterDisplay command: \(bdCmd)")
+            return Runner.shell(bdCmd)
+        }
+        return nil
+    }
+    
+    @discardableResult
+    static func setVolume(_ volume: Float, deviceName: String) -> String? {
+        return BetterDisplay.set("volume", value: String(volume), deviceName: deviceName)
+    }
+    
+    @discardableResult
+    static func mute(_ mute: Bool, deviceName: String) -> String? {
+        return BetterDisplay.set("mute", value: mute ? "on" : "off", deviceName: deviceName)
+    }
+}


### PR DESCRIPTION
If the audio device fails to set volume or mute:

- Check if the device is a possible display (connected via HDMI or DisplayPort)
- Check if BetterDisplay app is installed
- Execute the desired volume/mute option in BetterDisplay

### Why:

Some display audio devices (if not all) can't be controlled directly with macOS volume options or MultiSoundChanger. BetterDisplay makes this possible.

When controlling the volume of a multi-output device BetterDisplay magic is not applied, so this implementation solves this scenario.

https://github.com/waydabber/BetterDisplay/discussions/2194

### Includes:

The whitelist_rules configuration key has been renamed to only_rules on version 0.41.0 (Nov 8, 2020) https://github.com/realm/SwiftLint/releases/tag/0.41.0